### PR TITLE
Fix for VERIFIED/INVALID IPN response not working in debug mode

### DIFF
--- a/IPN_PHP.txt
+++ b/IPN_PHP.txt
@@ -95,7 +95,7 @@ if (curl_errno($ch) != 0) // cURL error
 			error_log(date('[Y-m-d H:i e] '). "HTTP response of validation request: $res" . PHP_EOL, 3, LOG_FILE);
 
 			// Split response headers and payload
-			list($headers, $res) = explode("\r\n\r\n", $res, 2);
+			list( , , $res) = explode("\r\n\r\n", $res);
 		}
 		curl_close($ch);
 }

--- a/IPN_PHP.txt
+++ b/IPN_PHP.txt
@@ -95,7 +95,11 @@ if (curl_errno($ch) != 0) // cURL error
 			error_log(date('[Y-m-d H:i e] '). "HTTP response of validation request: $res" . PHP_EOL, 3, LOG_FILE);
 
 			// Split response headers and payload
-			list( , , $res) = explode("\r\n\r\n", $res);
+			if(USE_SANDBOX == 1) {
+				list( , , $res) = explode("\r\n\r\n", $res);
+			} else {
+				list($headers, $res) = explode("\r\n\r\n", $res, 2);
+			}
 		}
 		curl_close($ch);
 }


### PR DESCRIPTION
When outputted to the ipn.log file, the $res variable (before splitting with explode) is as follows:
```
HTTP/1.1 100 Continue

HTTP/1.1 200 OK
Date: Fri, 11 Oct 2013 04:39:54 GMT
Server: Apache
X-Frame-Options: SAMEORIGIN
Set-Cookie: (8 lines of Set-Cookie, shortened here for display purposes)
Vary: Accept-Encoding
Strict-Transport-Security: max-age=14400
Transfer-Encoding: chunked
Content-Type: text/html; charset=UTF-8

VERIFIED
```

Line 98 is currently:

    list($headers, $res) = explode("\r\n\r\n", $res, 2);

but because there are 2 "\r\n\r\n" line breaks in the output, it currently sets the $res variable equal to the second block of code, instead of the third block that contains the VERIFIED/INVALID response.

The proposed change:

    list( , , $res) = explode("\r\n\r\n", $res);

resets the $res variable to contain just the IPN response code of VERIFIED or INVALID. 

This alternative line:

    list($http_status_code, $headers, $res) = explode("\r\n\r\n", $res);

could be used to better illustrate what is happening, but introduces 2 unnecessary variables.