### PR TITLE
Update paypal_ipn.cfm

### DIFF
--- a/paypal_ipn.cfm
+++ b/paypal_ipn.cfm
@@ -4,7 +4,7 @@
 <CFSET requestData = getHTTPRequestData() />
 
 <!--- add 'cmd' and post back to PayPal system to validate --->
-<CFHTTP url="https://www.paypal.com/cgi-bin/webscr?cmd=_notify-validate&#requestData.content#" >
+<CFHTTP url="https://www.paypal.com/cgi-bin/webscr?cmd=_notify-validate&#urlDecode(requestData.content)#" >
 	<cfhttpparam type="header"  name="Host" value="www.paypal.com"> 
 </CFHTTP>
 


### PR DESCRIPTION
For most submissions, the status will come back as invalid because it needs #UrlDecode()#'d before it's passed as part of the CFHTTP URL string.