### PR TITLE
Update paypal_ipn.php

### DIFF
--- a/paypal_ipn.php
+++ b/paypal_ipn.php
@@ -70,7 +70,7 @@ if(DEBUG == true) {
 
 // Set TCP timeout to 30 seconds
 curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 30);
-curl_setopt($ch, CURLOPT_HTTPHEADER, array('Connection: Close'));
+curl_setopt($ch, CURLOPT_HTTPHEADER, array('Connection: Close', 'User-Agent: company-name'));
 
 // CONFIG: Please download 'cacert.pem' from "http://curl.haxx.se/docs/caextract.html" and set the directory path
 // of the certificate as shown below. Ensure the file is readable by the webserver.


### PR DESCRIPTION
Adding user-agent in array will no longer cause 403 error in HTTP request.