### PR TITLE
Remove extra period from path to cacert.pem in paypal_ipn.php

### DIFF
--- a/paypal_ipn.php
+++ b/paypal_ipn.php
@@ -76,7 +76,7 @@ curl_setopt($ch, CURLOPT_HTTPHEADER, array('Connection: Close'));
 // of the certificate as shown below. Ensure the file is readable by the webserver.
 // This is mandatory for some environments.
 
-//$cert = __DIR__ . "./cacert.pem";
+//$cert = __DIR__ . "/cacert.pem";
 //curl_setopt($ch, CURLOPT_CAINFO, $cert);
 
 $res = curl_exec($ch);


### PR DESCRIPTION
Leaving this period in place results the code always adding a period to the directory the code resides in. This means that if the code is being hosted in `/var/www/paypal-test/` then the code will try to look up the _cacert.pem_ file under the file path:
`/var/www/paypal-test./cacert.pem`
where you will notice a period has been appended to the directory name.

I know this is a minor configuration thing but in the interests of providing code that works "out-of-the-box" as far as possible, I suggest this change be incorporated into the example.