### PR TITLE
function_exists('get_magic_quotes_gpc') does not need to get to variable

### DIFF
--- a/paypal_ipn.php
+++ b/paypal_ipn.php
@@ -25,11 +25,9 @@ foreach ($raw_post_array as $keyval) {
 }
 // read the post from PayPal system and add 'cmd'
 $req = 'cmd=_notify-validate';
-if(function_exists('get_magic_quotes_gpc')) {
-	$get_magic_quotes_exists = true;
-}
+
 foreach ($myPost as $key => $value) {
-	if($get_magic_quotes_exists == true && get_magic_quotes_gpc() == 1) {
+	if(function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc() == 1) {
 		$value = urlencode(stripslashes($value));
 	} else {
 		$value = urlencode($value);


### PR DESCRIPTION
Please make this suggestion, and make it shorter a bit.. this is more readable and there is no need to create variable for it..