### PR TITLE
removed payload.replace("+", "%2B")

### DIFF
--- a/javascript/googlescript.js
+++ b/javascript/googlescript.js
@@ -8,7 +8,6 @@ function doPost(e) {
   if (isProduction)  paypalURL = strLive;
   
   var payload = "cmd=_notify-validate&" + e.postData.contents;
-  payload = payload.replace("+", "%2B");
 
   var options =
     {


### PR DESCRIPTION
payload = payload.replace("+", "%2B"); is not needed. Using it returns INVALID as a response from IPN.