### PR TITLE
Keep plus in email addresses

### DIFF
--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -81,11 +81,10 @@ class PaypalIPN
                 // Keep plus in email addresses.
                 if (filter_var(rawurldecode($keyval[1]), FILTER_VALIDATE_EMAIL)) {
                     $myPost[$keyval[0]] = rawurldecode($keyval[1]);
-                    $_POST[$keyval[0]] = $myPost[$keyval[0]];
                 } else {
                     $myPost[$keyval[0]] = urldecode($keyval[1]);
-                    $_POST[$keyval[0]] = $myPost[$keyval[0]];
                 }
+                $_POST[$keyval[0]] = $myPost[$keyval[0]];
             }
         }
 

--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -81,7 +81,7 @@ class PaypalIPN
                 // Keep plus in email addresses.
                 if (filter_var(rawurldecode($keyval[1]), FILTER_VALIDATE_EMAIL)) {
                     $myPost[$keyval[0]] = rawurldecode($keyval[1]);
-                    $_POST[$keyval[0]] = rawurldecode($keyval[1]);
+                    $_POST[$keyval[0]] = $myPost[$keyval[0]];
                 } else {
                     $myPost[$keyval[0]] = urldecode($keyval[1]);
                     $_POST[$keyval[0]] = $myPost[$keyval[0]];

--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -51,7 +51,7 @@ class PaypalIPN
      */
     public function getPaypalUri()
     {
-        if ($this->use_sandbox) {
+        if (($this->use_sandbox) || ($_POST["test_ipn"] == 1)) {
             return self::SANDBOX_VERIFY_URI;
         } else {
             return self::VERIFY_URI;

--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -78,8 +78,8 @@ class PaypalIPN
         foreach ($raw_post_array as $keyval) {
             $keyval = explode('=', $keyval);
             if (count($keyval) == 2) {
-                // Keep plus in email addresses.
                 if (filter_var(rawurldecode($keyval[1]), FILTER_VALIDATE_EMAIL)) {
+                    // Keep plus in email addresses.
                     $myPost[$keyval[0]] = rawurldecode($keyval[1]);
                 } else {
                     $myPost[$keyval[0]] = urldecode($keyval[1]);

--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -78,13 +78,14 @@ class PaypalIPN
         foreach ($raw_post_array as $keyval) {
             $keyval = explode('=', $keyval);
             if (count($keyval) == 2) {
-                // Since we do not want the plus in the datetime string to be encoded to a space, we manually encode it.
-                if ($keyval[0] === 'payment_date') {
-                    if (substr_count($keyval[1], '+') === 1) {
-                        $keyval[1] = str_replace('+', '%2B', $keyval[1]);
-                    }
+                // Keep plus in email addresses.
+                if (filter_var(rawurldecode($keyval[1]), FILTER_VALIDATE_EMAIL)) {
+                    $myPost[$keyval[0]] = rawurldecode($keyval[1]);
+                    $_POST[$keyval[0]] = rawurldecode($keyval[1]);
+                } else {
+                    $myPost[$keyval[0]] = urldecode($keyval[1]);
+                    $_POST[$keyval[0]] = $myPost[$keyval[0]];
                 }
-                $myPost[$keyval[0]] = urldecode($keyval[1]);
             }
         }
 
@@ -96,9 +97,9 @@ class PaypalIPN
         }
         foreach ($myPost as $key => $value) {
             if ($get_magic_quotes_exists == true && get_magic_quotes_gpc() == 1) {
-                $value = urlencode(stripslashes($value));
+                $value = rawurlencode(stripslashes($value));
             } else {
-                $value = urlencode($value);
+                $value = rawurlencode($value);
             }
             $req .= "&$key=$value";
         }

--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -51,7 +51,7 @@ class PaypalIPN
      */
     public function getPaypalUri()
     {
-        if (($this->use_sandbox) || ($_POST["test_ipn"] == 1)) {
+        if ($this->use_sandbox) {
             return self::SANDBOX_VERIFY_URI;
         } else {
             return self::VERIFY_URI;

--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -87,6 +87,7 @@ class PaypalIPN
                 $_POST[$keyval[0]] = $myPost[$keyval[0]];
             }
         }
+        ksort($_POST);
 
         // Build the body of the verification post request, adding the _notify-validate command.
         $req = 'cmd=_notify-validate';


### PR DESCRIPTION
This keeps plus signs in email addresses so that they do not cause it to fail.

This has been tested on the simulator and on live.