### PR TITLE
added namespace to example_usage.php

### DIFF
--- a/php/example_usage.php
+++ b/php/example_usage.php
@@ -1,4 +1,8 @@
-<?php require('PaypalIPN.php');
+<?php 
+
+namespace Listener;
+
+require('PaypalIPN.php');
 
 use PaypalIPN;
 


### PR DESCRIPTION
This change resolves a PHP warning that is generated by improper namespace usage:
   PHP Warning:  The use statement with non-compound name 'PaypalIPN' has no effect in example_usage.php on line 3
Depending on how a dev decides to process IPN requests, this could cause problems other than just the warning.
This fork resolves Issue #77 