### PR TITLE
moved listener up for consistency

### DIFF
--- a/php/example_usage.php
+++ b/php/example_usage.php
@@ -1,6 +1,4 @@
-<?php 
-
-namespace Listener;
+<?php namespace Listener;
 
 require('PaypalIPN.php');
 


### PR DESCRIPTION
The listener is required to be set before anything else and will give an error otherwise. May as well put it at the very top.