### PR TITLE
Update paypal_ipn.vb

### DIFF
--- a/visual_basic/paypal_ipn.vb
+++ b/visual_basic/paypal_ipn.vb
@@ -28,6 +28,9 @@ req.ContentLength = strRequest.Length
 Dim streamOut As StreamWriter = New StreamWriter(req.GetRequestStream(), Encoding.ASCII)
 streamOut.Write(strRequest)
 streamOut.Close()
+    
+ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3 Or SecurityProtocolType.Tls12     
+    
 Dim streamIn As StreamReader = New StreamReader(req.GetResponse().GetResponseStream())
 Dim strResponse As String = streamIn.ReadToEnd()
 streamIn.Close()

--- a/visual_basic/paypal_ipn.vb
+++ b/visual_basic/paypal_ipn.vb
@@ -29,7 +29,7 @@ Dim streamOut As StreamWriter = New StreamWriter(req.GetRequestStream(), Encodin
 streamOut.Write(strRequest)
 streamOut.Close()
     
-ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3 Or SecurityProtocolType.Tls12     
+ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12     
     
 Dim streamIn As StreamReader = New StreamReader(req.GetResponse().GetResponseStream())
 Dim strResponse As String = streamIn.ReadToEnd()


### PR DESCRIPTION
Will be great if you can add this before the call back to PayPal for verification:
ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3 Or SecurityProtocolType.Tls12 

I found that the code fails beyond the verification callback with the error: "The request was aborted: Could not create SSL/TLS secure channel."
Thanks!