### PR TITLE
Fix for plus signs in data and verified array

### DIFF
--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -83,7 +83,7 @@ class PaypalIPN
             $keyval = explode('=', $keyval);
             if (count($keyval) == 2) {
                 // Since we do not want the plus signs in the date and email strings to be encoded to a space, we use rawurldecode instead of urldecode
-                if (($keyval[0] === 'payment_date' && substr_count($keyval[1], '+') === 1) || strpos(rawurldecode($keyval[1]), ' ') !== false || filter_var($keyval[1], FILTER_VALIDATE_EMAIL)) {
+                if (($keyval[0] === 'payment_date' && substr_count($keyval[1], '+') === 1) || strpos(rawurldecode($keyval[1]), ' ') !== false || ($_POST["test_ipn"] == 1 && filter_var($keyval[1], FILTER_VALIDATE_EMAIL))) {
                     // Keep plus signs
                     $myPost[$keyval[0]] = rawurldecode($keyval[1]);
                 } else {

--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -83,7 +83,7 @@ class PaypalIPN
             $keyval = explode('=', $keyval);
             if (count($keyval) == 2) {
                 // Since we do not want the plus signs in the date and email strings to be encoded to a space, we use rawurldecode instead of urldecode
-                if (($keyval[0] === 'payment_date' && substr_count($keyval[1], '+') === 1) || strpos(rawurldecode($keyval[1]), ' ') !== false || ($_POST["test_ipn"] == 1 && filter_var($keyval[1], FILTER_VALIDATE_EMAIL))) {
+                if (($keyval[0] === 'payment_date' && substr_count($keyval[1], '+') === 1) || strpos(rawurldecode($keyval[1]), ' ') !== false || filter_var($keyval[1], FILTER_VALIDATE_EMAIL)) {
                     // Keep plus signs
                     $myPost[$keyval[0]] = rawurldecode($keyval[1]);
                 } else {

--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -83,11 +83,11 @@ class PaypalIPN
             if (count($keyval) == 2) {
                 // Since we do not want the plus signs in the date and email strings to be encoded to a space, we use rawurldecode instead of urldecode
                 if (
-                    // If a single plus sign is found in date...
+                    // single plus sign found in date
                     ($keyval[0] === 'payment_date' && substr_count($keyval[1], '+') === 1)
-                    // If a space is found that was not encoded using a plus sign...
+                    // space found that was not encoded using a plus sign
                     || strpos(rawurldecode($keyval[1]), ' ') !== false
-                    // If an un-encoded email address is found when receiving data from the sandbox...
+                    // un-encoded email address found when receiving data from the simulator
                     || ($_POST["test_ipn"] == 1 && filter_var($keyval[1], FILTER_VALIDATE_EMAIL))
                 ) {
                     // Keep plus signs

--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -83,7 +83,7 @@ class PaypalIPN
             $keyval = explode('=', $keyval);
             if (count($keyval) == 2) {
                 // Since we do not want the plus signs in the date and email strings to be encoded to a space, we use rawurldecode instead of urldecode
-                if (($keyval[0] === 'payment_date' && substr_count($keyval[1], '+') === 1) || strpos(rawurldecode($keyval[1]), ' ') !== false || ($_POST["test_ipn"] == 1 && filter_var(rawurldecode($keyval[1]), FILTER_VALIDATE_EMAIL))) {
+                if (($keyval[0] === 'payment_date' && substr_count($keyval[1], '+') === 1) || strpos(rawurldecode($keyval[1]), ' ') !== false || ($_POST["test_ipn"] == 1 && filter_var($keyval[1], FILTER_VALIDATE_EMAIL))) {
                     // Keep plus signs
                     $myPost[$keyval[0]] = rawurldecode($keyval[1]);
                 } else {

--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -137,7 +137,7 @@ class PaypalIPN
 
         curl_close($ch);
 
-        // Check if PayPal verifies the IPN data, and if so, return true.
+        // Check if PayPal verifies the IPN data, and if so, return data array.
         if ($res == self::VALID) {
             return $myPost;
         }

--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -78,7 +78,6 @@ class PaypalIPN
         $raw_post_data = file_get_contents('php://input');
         $raw_post_array = explode('&', $raw_post_data);
         $myPost = array();
-        $magic_quotes_enabled = false;
         foreach ($raw_post_array as $keyval) {
             $keyval = explode('=', $keyval);
             if (count($keyval) == 2) {

--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -72,6 +72,11 @@ class PaypalIPN
             throw new Exception("Missing POST Data");
         }
 
+        $get_magic_quotes_exists = false;
+        if (function_exists('get_magic_quotes_gpc')) {
+            $get_magic_quotes_exists = true;
+        }
+
         $raw_post_data = file_get_contents('php://input');
         $raw_post_array = explode('&', $raw_post_data);
         $myPost = array();
@@ -86,21 +91,16 @@ class PaypalIPN
                     // Convert plus signs to spaces
                     $myPost[$keyval[0]] = urldecode($keyval[1]);
                 }
+                if ($get_magic_quotes_exists == true && get_magic_quotes_gpc() == 1) {
+                    $myPost[$keyval[0]] = stripslashes($myPost[$keyval[0]]);
+                }
             }
         }
 
         // Build the body of the verification post request, adding the _notify-validate command.
         $req = 'cmd=_notify-validate';
-        $get_magic_quotes_exists = false;
-        if (function_exists('get_magic_quotes_gpc')) {
-            $get_magic_quotes_exists = true;
-        }
         foreach ($myPost as $key => $value) {
-            if ($get_magic_quotes_exists == true && get_magic_quotes_gpc() == 1) {
-                $value = rawurlencode(stripslashes($value));
-            } else {
-                $value = rawurlencode($value);
-            }
+            $value = rawurlencode($value);
             $req .= "&$key=$value";
         }
 

--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -72,14 +72,13 @@ class PaypalIPN
             throw new Exception("Missing POST Data");
         }
 
-        $get_magic_quotes_exists = false;
-        if (function_exists('get_magic_quotes_gpc')) {
-            $get_magic_quotes_exists = true;
-        }
-
         $raw_post_data = file_get_contents('php://input');
         $raw_post_array = explode('&', $raw_post_data);
         $myPost = array();
+        $magic_quotes_enabled = false;
+        if (function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc() == 1) {
+            $magic_quotes_enabled = true;
+        }
         foreach ($raw_post_array as $keyval) {
             $keyval = explode('=', $keyval);
             if (count($keyval) == 2) {
@@ -91,7 +90,7 @@ class PaypalIPN
                     // Convert plus signs to spaces
                     $myPost[$keyval[0]] = urldecode($keyval[1]);
                 }
-                if ($get_magic_quotes_exists == true && get_magic_quotes_gpc() == 1) {
+                if ($magic_quotes_enabled) {
                     $myPost[$keyval[0]] = stripslashes($myPost[$keyval[0]]);
                 }
             }

--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -89,9 +89,9 @@ class PaypalIPN
                 } else {
                     // Convert plus signs to spaces
                     $myPost[$keyval[0]] = urldecode($keyval[1]);
-                }
-                if ($magic_quotes_enabled) {
-                    $myPost[$keyval[0]] = stripslashes($myPost[$keyval[0]]);
+                    if ($magic_quotes_enabled) {
+                        $myPost[$keyval[0]] = stripslashes($myPost[$keyval[0]]);
+                    }
                 }
             }
         }

--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -83,7 +83,7 @@ class PaypalIPN
             $keyval = explode('=', $keyval);
             if (count($keyval) == 2) {
                 // Since we do not want the plus signs in the date and email strings to be encoded to a space, we use rawurldecode instead of urldecode
-                if (($keyval[0] === 'payment_date' && substr_count($keyval[1], '+') === 1) || strpos(rawurldecode($keyval[1]), ' ') !== false || filter_var(rawurldecode($keyval[1]), FILTER_VALIDATE_EMAIL)) {
+                if (($keyval[0] === 'payment_date' && substr_count($keyval[1], '+') === 1) || strpos(rawurldecode($keyval[1]), ' ') !== false || ($_POST["test_ipn"] == 1 && filter_var(rawurldecode($keyval[1]), FILTER_VALIDATE_EMAIL))) {
                     // Keep plus signs
                     $myPost[$keyval[0]] = rawurldecode($keyval[1]);
                 } else {

--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -83,11 +83,11 @@ class PaypalIPN
             if (count($keyval) == 2) {
                 // Since we do not want the plus signs in the date and email strings to be encoded to a space, we use rawurldecode instead of urldecode
                 if (
-                    // If a single plus sign is found in date, then do not replace plus signs with spaces
+                    // If a single plus sign is found in date...
                     ($keyval[0] === 'payment_date' && substr_count($keyval[1], '+') === 1)
-                    // If a space is found that was not encoded using a plus sign, then do not replace plus signs with spaces
+                    // If a space is found that was not encoded using a plus sign...
                     || strpos(rawurldecode($keyval[1]), ' ') !== false
-                    // If an un-encoded email address is found when receiving data from the sandbox, then do not replace plus signs with spaces
+                    // If an un-encoded email address is found when receiving data from the sandbox...
                     || ($_POST["test_ipn"] == 1 && filter_var($keyval[1], FILTER_VALIDATE_EMAIL))
                 ) {
                     // Keep plus signs

--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -63,7 +63,7 @@ class PaypalIPN
      * Verification Function
      * Sends the incoming post data back to PayPal using the cURL library.
      *
-     * @return array or bool false
+     * @return array or false
      * @throws Exception
      */
     public function verifyIPN()


### PR DESCRIPTION
$_POST can in some instances decode plus signs incorrectly, and can not in all possible instances be trusted to have decoded the data correctly.

With this change, you may instead use an array that has had its contents completely verified for accuracy.

Using the function urlencode with an email address that contains plus signs, may cause the plus signs to encode as a space instead of a plus. This would prevent the data from being validated with email addresses with plus signs. It is safer to use rawurlencode instead.