### PR TITLE
Update PHP to allow caller to set curl options

### DIFF
--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -58,7 +58,7 @@ class PaypalIPN
      * @return bool
      * @throws Exception
      */
-    public function verifyIPN()
+    public function verifyIPN($ch = null)
     {
         if ( ! count($_POST)) {
             throw new Exception("Missing POST Data");
@@ -96,7 +96,9 @@ class PaypalIPN
         }
 
         // Post the data back to PayPal, using curl. Throw exceptions if errors occur.
-        $ch = curl_init($this->getPaypalUri());
+        if (! isset($ch))
+            $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $this->getPaypalUri());
         curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
         curl_setopt($ch, CURLOPT_POST, 1);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);


### PR DESCRIPTION
Many production environments restrict outgoing network access on their servers that deal with payments, only allowing such access through proxies that vet the destinations before allowing access. This patch provides an option for the caller of verifyIPN() to provide the curl object for verifyIPN() to use instead of allocating its own curl object. This allows the caller to set any proxy options, or other options, that may be required in order to allow the connection back to Paypal to work.

I first tried adding methods to the PaypalIPN class for setting proxy options, but PHP curl has a very large number of proxy settings. The majority of cases in practice could probably be handled with only two or three options, but the approach proposed in this pull request handles all the cases, so I abandoned the other approach. If anyone wants to see that approach, it is on a branch in my clone of this repository, available [here](https://github.com/tzs/ipn-code-samples/tree/tzs-patch-1)