### PR TITLE
Update PHP to allow caller to set curl options

### DIFF
--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -6,7 +6,7 @@ class PaypalIPN
     private $use_sandbox = false;
     /** @var bool Indicates if the local certificates are used. */
     private $use_local_certs = true;
-    /** @var curl handler */
+    /** @var resource cURL session handle */
     private $curl_handler = null;
 
     /** Production Postback URL */
@@ -19,6 +19,14 @@ class PaypalIPN
     /** Response from PayPal indicating validation failed */
     const INVALID = 'INVALID';
 
+    /**
+     * Construct a PaypalIPN instance that will use the cURL session
+     * handle that you supply, as opposed to creating a new cURL session
+     * handle like the default constructor does.
+     *
+     * @param resource $curl_handler (optional) cURL session handle
+     * @return void
+     */
     public function __construct($curl_handler = null)
     {
         $this->curl_handler = $curl_handler;

--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -6,6 +6,8 @@ class PaypalIPN
     private $use_sandbox = false;
     /** @var bool Indicates if the local certificates are used. */
     private $use_local_certs = true;
+    /** @var curl handler */
+    private $curl_handler = null;
 
     /** Production Postback URL */
     const VERIFY_URI = 'https://ipnpb.paypal.com/cgi-bin/webscr';
@@ -16,6 +18,11 @@ class PaypalIPN
     const VALID = 'VERIFIED';
     /** Response from PayPal indicating validation failed */
     const INVALID = 'INVALID';
+
+    public function __construct($curl_handler = null)
+    {
+        $this->curl_handler = $curl_handler;
+    }
 
     /**
      * Sets the IPN verification to sandbox mode (for use when testing,
@@ -96,7 +103,8 @@ class PaypalIPN
         }
 
         // Post the data back to PayPal, using curl. Throw exceptions if errors occur.
-        $ch = curl_init($this->getPaypalUri());
+        $ch = isset($this->curl_handler) ? $this->curl_handler : curl_init();
+        curl_setopt($ch, CURLOPT_URL, $this->getPaypalUri());
         curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
         curl_setopt($ch, CURLOPT_POST, 1);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);


### PR DESCRIPTION
Many production environments restrict outgoing network access on their servers that deal with payments, only allowing such access through proxies that vet the destinations before allowing access. This patch provides an option for the caller of verifyIPN() to provide the curl object for verifyIPN() to use instead of allocating its own curl object. This allows the caller to set any proxy options, or other options, that may be required in order to allow the connection back to Paypal to work.